### PR TITLE
Adiciona o método PATCH a lista de métodos permitidos na política de CORS

### DIFF
--- a/src/main/java/tcc/uff/resource/server/configuration/SecurityConfig.java
+++ b/src/main/java/tcc/uff/resource/server/configuration/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
     private CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://alunopresente-hml.vercel.app", "https://alunopresente.vercel.app","http://localhost:3000/"));
-        configuration.setAllowedMethods(Arrays.asList("POST", "GET", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("POST", "PATCH", "GET", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Access-Control-Allow-Headers", "Content-Type", "Authorization", "Content-Length", "X-Requested-With", "Accept"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
Conforme citado em #8 , algumas requisições patch estão sendo bloqueadas pela política de cors.

Fiz essas alterações, porém, não consegui validar se estão funcionando (Preciso acertar o ambiente aqui para rodar o backend).

Consegue validar se é só isso, por favor?